### PR TITLE
dropped gcr.io: tensorflow docker image moved

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/tensorflow/tensorflow
+FROM tensorflow/tensorflow
 RUN apt-get update && apt-get install -y git-core
 RUN pip install tqdm
 RUN git clone https://github.com/Steven-Hewitt/Entailment-with-Tensorflow.git /notebooks/Entailment


### PR DESCRIPTION
As per https://stackoverflow.com/questions/51832339/need-help-installing-tensorflow-docker-image .. docker tensorflow has moved